### PR TITLE
Added automatic Oneshot125 detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 *.hex
 *.obj
+*.cof
+*.cproject
+*.project
+*.asm
+!tgy.asm
+tgy.sublime-project
+tgy.sublime-workspace

--- a/bs_nfet.inc
+++ b/bs_nfet.inc
@@ -12,6 +12,7 @@
 .equ	USE_UART	= 0
 .equ	USE_ICP		= 0
 .equ	COMP_PWM	= 1
+.equ	ONESHOT125	= 1
 
 .equ	DEAD_LOW_NS	= 300
 .equ	DEAD_HIGH_NS	= 300

--- a/bs_nfet.inc
+++ b/bs_nfet.inc
@@ -11,6 +11,7 @@
 .equ	USE_I2C		= 0	; We could, but FETs are on the I2C ports
 .equ	USE_UART	= 0
 .equ	USE_ICP		= 0
+.equ	COMP_PWM	= 1
 
 .equ	DEAD_LOW_NS	= 300
 .equ	DEAD_HIGH_NS	= 300


### PR DESCRIPTION
When ONESHOT125 is defined in the *.inc file (only useful when combined
with COMP_PWM defined) the rc puls length is automatically detected and
adjusted for oneshot125 and/or normal range PWM input (1000-2000uSec).