### PR TITLE
Added support for newer RB70A ESCs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL = /bin/bash
 
 .SUFFIXES: .inc .hex
 
-ALL_TARGETS = afro.hex afro2.hex afro_hv.hex afro_nfet.hex arctictiger.hex birdie70a.hex bs_nfet.hex bs.hex bs40a.hex dlu40a.hex dlux.hex dys_nfet.hex hk200a.hex hm135a.hex hxt200a.hex kda.hex kda_8khz.hex kda_nfet.hex kda_nfet_ni.hex mkblctrl1.hex rb50a.hex rb70a.hex rct50a.hex tbs.hex tbs_hv.hex tp.hex tp_8khz.hex tp_i2c.hex tp_nfet.hex tp70a.hex tgy6a.hex tgy_8mhz.hex tgy.hex
+ALL_TARGETS = afro.hex afro2.hex afro_hv.hex afro_nfet.hex arctictiger.hex birdie70a.hex bs_nfet.hex bs.hex bs40a.hex dlu40a.hex dlux.hex dys_nfet.hex hk200a.hex hm135a.hex hxt200a.hex kda.hex kda_8khz.hex kda_nfet.hex kda_nfet_ni.hex mkblctrl1.hex rb50a.hex rb70a.hex rb70a2.hex rct50a.hex tbs.hex tbs_hv.hex tp.hex tp_8khz.hex tp_i2c.hex tp_nfet.hex tp70a.hex tgy6a.hex tgy_8mhz.hex tgy.hex
 AUX_TARGETS = afro_pr0.hex afro_pr1.hex diy0.hex
 
 all: $(ALL_TARGETS)

--- a/rb70a.inc
+++ b/rb70a.inc
@@ -1,8 +1,9 @@
-;********************************************
-;* Red Brick 70A with all FETs on PORTD     *
-;* Also Red Brick 200A black (RB200A-BTO)   *
-;* Original fuses are lfuse:0x3f hfuse:0xc1 *
-;********************************************
+;*****************************************************
+;* Red Brick 70A with all FETs on PORTD              *
+;* Also Red Brick 200A black (RB200A-BTO)            *
+;* Original fuses are lfuse:0x3f hfuse:0xc1          *
+;* If your pcb is blue, you probably need rb70a2.inc *
+;*****************************************************
 
 .equ	F_CPU		= 16000000
 .equ	USE_INT0	= 1

--- a/rb70a2.inc
+++ b/rb70a2.inc
@@ -1,0 +1,65 @@
+;********************************************
+;* Red Brick 70A first seen September 2015  *
+;* Blue circuit board labeled 4P0529A       *
+;* If this doesn't work, try rb70a or rb50a *
+;* Also new blue HK SS 190-200A boards      *
+;********************************************
+
+.equ    F_CPU           = 16000000
+.equ    USE_INT0        = 1
+.equ    USE_I2C         = 0
+.equ    USE_UART        = 0
+.equ    USE_ICP         = 0
+
+;*********************
+; PORT D definitions *
+;*********************
+.equ    c_comp          = 6     ;10 i common comparator input (AIN0)
+.equ    AnFET           = 5     ;30 o
+.equ    ApFET           = 4     ;31 o
+.equ    rcp_in          = 2     ;32 i r/c pulse input
+
+.equ    INIT_PD         = 0
+.equ    DIR_PD          = (1<<ApFET)+(1<<AnFET)
+
+.equ    ApFET_port      = PORTD
+.equ    AnFET_port      = PORTD
+
+;*********************
+; PORT C definitions *
+;*********************
+.equ    mux_c           = 7     ; ADC7 voltage input (47k from Vbat, 2.0k to gnd, 10.10V in -> .402V at ADC7)
+.equ    mux_a           = 6     ; ADC6
+.equ    BpFET           = 5     ; ADC5
+.equ    CnFET           = 4     ; ADC4
+.equ    CpFET           = 3     ; ADC3
+.equ    mux_voltage     = 2     ; ADC2
+;.equ                   = 1     ; ADC1
+.equ    mux_b           = 0     ; ADC0
+
+.equ    BpFET_port      = PORTC
+.equ    CpFET_port      = PORTC
+.equ    CnFET_port      = PORTC
+
+.equ    O_POWER         = 47
+.equ    O_GROUND        = 2
+
+.equ    INIT_PC         = 0
+.equ    DIR_PC          = (1<<BpFET)+(1<<CpFET)+(1<<CnFET)
+
+;*********************
+; PORT B definitions *
+;*********************
+;.equ                   = 7
+;.equ                   = 6
+;.equ                   = 5     (sck stk200 interface)
+;.equ                   = 4     (miso stk200 interface)
+;.equ                   = 3     (mosi stk200 interface)
+;.equ                   = 2
+;.equ                   = 1
+.equ   BnFET            = 0
+
+.equ    BnFET_port      = PORTB
+
+.equ    INIT_PB         = 0
+.equ    DIR_PB          = (1<<BnFET)

--- a/tgy.asm
+++ b/tgy.asm
@@ -130,6 +130,8 @@
 #include "rb50a.inc"		; Red Brick 50A with all nFETs (INT0 PWM)
 #elif defined(rb70a_esc)
 #include "rb70a.inc"		; Red Brick 70A with all nFETs (INT0 PWM)
+#elif defined(rb70a2_esc)
+#include "rb70a2.inc"		; Newer Red Brick 70A with blue pcb and all nFETs (INT0 PWM)
 #elif defined(rct50a_esc)
 #include "rct50a.inc"		; RCTimer 50A (MLF version) with all nFETs (INT0 PWM)
 #elif defined(tbs_esc)


### PR DESCRIPTION
I decided to just call it rb70a2.inc as it seems that's what you've done in the past. Did I miss anything else that needs to be updated? How do we update the Google Docs spreadsheet?