### PR TITLE
remove needs to change Makefile and tgy.asm for a new board configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,25 +5,39 @@ SHELL = /bin/bash
 
 .SUFFIXES: .inc .hex
 
-ALL_TARGETS = afro.hex afro2.hex afro_hv.hex afro_nfet.hex arctictiger.hex birdie70a.hex bs_nfet.hex bs.hex bs40a.hex dlu40a.hex dlux.hex dys_nfet.hex hk200a.hex hm135a.hex hxt200a.hex kda.hex kda_8khz.hex kda_nfet.hex kda_nfet_ni.hex mkblctrl1.hex rb50a.hex rb70a.hex rb70a2.hex rct50a.hex tbs.hex tbs_hv.hex tp.hex tp_8khz.hex tp_i2c.hex tp_nfet.hex tp70a.hex tgy6a.hex tgy_8mhz.hex tgy.hex
-AUX_TARGETS = afro_pr0.hex afro_pr1.hex diy0.hex
+AUX_TARGETS = $(patsubst %.inc,%.hex,$(wildcard *_pr[0-9]*.inc diy*.inc))
+CPU_INC = $(wildcard m*def.inc)
+ALL_INC = $(sort $(wildcard *.inc))
+FILTER_TARGETS = boot.inc $(AUX_TARGETS) $(CPU_INC) $(pathsubst %.hex,%.inc,$(AUX_TARGETS))
+ALL_TARGETS = $(patsubst %.inc,%.hex,$(filter-out $(FILTER_TARGETS),$(ALL_INC)))
 
-all: $(ALL_TARGETS)
+.PHONY: all report_all
+all: report_all $(ALL_TARGETS)
+report_all::
+	@echo "Building: $(ALL_TARGETS)"
+
+.PHONY: aux report_aux
+aux: report_aux $(AUX_TARGETS)
+report_aux::
+	@echo "Building: $(AUX_TARGETS)"
 
 $(ALL_TARGETS): tgy.asm boot.inc
 $(AUX_TARGETS): tgy.asm boot.inc
 
 .inc.hex:
-	@test -e $*.asm || ln -s tgy.asm $*.asm
+	@if test ! -e $*.asm ; then (grep -q "^.include \"m.*def.inc\"" $*.inc || echo ".include \"m8def.inc\"" ; echo ".include \"$*.inc\"";echo ".include \"tgy.asm\"") > $*.asm ; touch $*.asm.created; fi
 	@echo "$(ASM) -fI -o $@ -D $*_esc -e $*.eeprom -d $*.obj $*.asm"
 	@set -o pipefail; $(ASM) -fI -o $@ -D $*_esc -e $*.eeprom -d $*.obj $*.asm 2>&1 | sed '/PRAGMA directives currently ignored/d'
-	@test -L $*.asm && rm -f $*.asm || true
+	@test -e $*.asm.created && rm -f $*.asm $*.asm.created || true
 
+.PHONY: test
 test: all
 
+.PHONY: clean
 clean:
-	-rm -f $(ALL_TARGETS) *.cof *.obj *.eep.hex *.eeprom
+	-rm -f $(ALL_TARGETS) $(AUX_TARGETS) *.cof *.obj *.eep.hex *.eeprom
 
+.PHONY: binary_zip
 binary_zip: $(ALL_TARGETS)
 	TARGET="tgy_`date '+%Y-%m-%d'`_`git rev-parse --verify --short HEAD`"; \
 	mkdir "$$TARGET" && \

--- a/tgy.asm
+++ b/tgy.asm
@@ -48,9 +48,20 @@
 ;
 ; Simon Kirby <sim@simulated.ca>
 ;
+
+; the default include when building tgy - the others are handles via make
+#if defined(tgy_esc)
+#include "m8def.inc"
+#include "tgy.inc"	; TowerPro/Turnigy Basic/Plush "type 2" (INT0 PWM)
+#endif
+
+; just in case check for some defines
+#if !defined(SREG) || !defined(F_CPU)
+#error "No board or CPU is defined"
+#endif
+
 ;-- Device ----------------------------------------------------------------
 ;
-.include "m8def.inc"
 ;
 ; 8K Bytes of In-System Self-Programmable Flash
 ; 512 Bytes EEPROM
@@ -80,83 +91,6 @@
 ;
 ; The following only works with avra or avrasm2.
 ; For avrasm32, just comment out all but the include you need.
-#if defined(afro_esc)
-#include "afro.inc"		; AfroESC (ICP PWM, I2C, UART)
-#elif defined(afro2_esc)
-#include "afro2.inc"		; AfroESC 2 (ICP PWM, I2C, UART)
-#elif defined(afro_hv_esc)
-#include "afro_hv.inc"		; AfroESC HV with drivers (ICP PWM, I2C, UART)
-#elif defined(afro_nfet_esc)
-#include "afro_nfet.inc"	; AfroESC 3 with all nFETs (ICP PWM, I2C, UART)
-#elif defined(afro_pr0_esc)
-#include "afro_pr0.inc"		; AfroESC prototype rev0 with NCP5911 (ICP PWM)
-#elif defined(afro_pr1_esc)
-#include "afro_pr1.inc"		; AfroESC prototype rev1 with NCP5911 (ICP PWM)
-#elif defined(arctictiger_esc)
-#include "arctictiger.inc"	; Arctic Tiger 30A ESC with all nFETs (ICP PWM)
-#elif defined(birdie70a_esc)
-#include "birdie70a.inc"	; Birdie 70A with all nFETs (INT0 PWM)
-#elif defined(mkblctrl1_esc)
-#include "mkblctrl1.inc"	; MK BL-Ctrl v1.2 (ICP PWM, I2C, UART, high side PWM, sense hack)
-#elif defined(bs_esc)
-#include "bs.inc"		; HobbyKing BlueSeries / Mystery (INT0 PWM)
-#elif defined(bs_nfet_esc)
-#include "bs_nfet.inc"		; HobbyKing BlueSeries / Mystery with all nFETs (INT0 PWM)
-#elif defined(bs40a_esc)
-#include "bs40a.inc"		; HobbyKing BlueSeries / Mystery 40A (INT0 PWM)
-#elif defined(dlu40a_esc)
-#include "dlu40a.inc"		; Pulso Advance Plus 40A DLU40A inverted-PWM-opto (INT0 PWM)
-#elif defined(dlux_esc)
-#include "dlux.inc"		; HobbyKing Dlux Turnigy ESC 20A
-#elif defined(diy0_esc)
-#include "diy0.inc"		; HobbyKing DIY Open ESC (unreleased rev 0)
-#elif defined(dys_nfet_esc)
-#include "dys_nfet.inc"		; DYS 30A ESC with all nFETs (ICP PWM, I2C, UART)
-#elif defined(hk200a_esc)
-#include "hk200a.inc"		; HobbyKing SS Series 190-200A with all nFETs (INT0 PWM)
-#elif defined(hm135a_esc)
-#include "hm135a.inc"		; Hacker/Jeti Master 135-O-F5B 135A inverted-PWM-opto (INT0 PWM)
-#elif defined(hxt200a_esc)
-#include "hxt200a.inc"		; HexTronik F3J HXT200A HV ESC (INT0 PWM, I2C, UART)
-#elif defined(kda_esc)
-#include "kda.inc"		; Keda/Multistar 12A, 20A, 30A (original) (inverted INT0 PWM)
-#elif defined(kda_8khz_esc)
-#include "kda_8khz.inc"		; Keda/Multistar 30A (early 2014) (inverted INT0 PWM)
-#elif defined(kda_nfet_esc)
-#include "kda_nfet.inc"		; Keda/Multistar 30A with all nFETs (inverted INT0 PWM)
-#elif defined(kda_nfet_ni_esc)
-#include "kda_nfet_ni.inc"	; Keda/Multistar/Sunrise ~30A with all nFETs (INT0 PWM)
-#elif defined(rb50a_esc)
-#include "rb50a.inc"		; Red Brick 50A with all nFETs (INT0 PWM)
-#elif defined(rb70a_esc)
-#include "rb70a.inc"		; Red Brick 70A with all nFETs (INT0 PWM)
-#elif defined(rb70a2_esc)
-#include "rb70a2.inc"		; Newer Red Brick 70A with blue pcb and all nFETs (INT0 PWM)
-#elif defined(rct50a_esc)
-#include "rct50a.inc"		; RCTimer 50A (MLF version) with all nFETs (INT0 PWM)
-#elif defined(tbs_esc)
-#include "tbs.inc"		; TBS 30A ESC (Team BlackSheep) with all nFETs (ICP PWM, UART)
-#elif defined(tbs_hv_esc)
-#include "tbs_hv.inc"		; TBS high voltage ESC (Team BlackSheep) with all nFETs (ICP PWM, UART)
-#elif defined(tp_esc)
-#include "tp.inc"		; TowerPro 25A/HobbyKing 18A "type 1" (INT0 PWM)
-#elif defined(tp_8khz_esc)
-#include "tp_8khz.inc"		; TowerPro 25A/HobbyKing 18A "type 1" (INT0 PWM) at 8kHz PWM
-#elif defined(tp_i2c_esc)
-#include "tp_i2c.inc"		; TowerPro 25A/HobbyKing 18A "type 1" (I2C)
-#elif defined(tp_nfet_esc)
-#include "tp_nfet.inc"		; TowerPro 25A with all nFETs "type 3" (INT0 PWM)
-#elif defined(tp70a_esc)
-#include "tp70a.inc"		; TowerPro 70A with BL8003 FET drivers (INT0 PWM)
-#elif defined(tgy6a_esc)
-#include "tgy6a.inc"		; Turnigy Plush 6A (INT0 PWM)
-#elif defined(tgy_8mhz_esc)
-#include "tgy_8mhz.inc"		; TowerPro/Turnigy Basic/Plush "type 2" w/8MHz oscillator (INT0 PWM)
-#elif defined(tgy_esc)
-#include "tgy.inc"		; TowerPro/Turnigy Basic/Plush "type 2" (INT0 PWM)
-#else
-#error "Unrecognized board type."
-#endif
 
 .equ	CPU_MHZ		= F_CPU / 1000000
 


### PR DESCRIPTION
Enabled automatic discovery of board includes in Makefile (removing manual list)
Removed the manually added board includes in tgy.asm (with a workarround for tgy.inc)
Made it possible (in principle) to use a different m*def.inc inside the <board>.inc
Made some of the targets phony