### PR TITLE
several patches that mean a dramatic power reduction while in idle/armed + neutral

### DIFF
--- a/tgy.asm
+++ b/tgy.asm
@@ -1213,6 +1213,18 @@ eeprom_defaults_w:
 
 ;-- RC pulse setup and edge handling macros ------------------------------
 
+.macro int0_set_rising_edge
+               in      @0, MCUCR
+               sbr     @0, (1<<ISC01) + (1<<ISC00) + SLEEP_FLAGS
+               out     MCUCR, @0
+.endmacro
+.macro int0_set_falling_edge
+               in      @0, MCUCR
+               cbr     @0, (1<<ISC00)
+               sbr     @0, (1<<ISC01) + SLEEP_FLAGS
+               out     MCUCR, @0
+.endmacro
+
 .if USE_ICP
 .macro rcp_int_enable
 		in	@0, TIMSK
@@ -1242,21 +1254,17 @@ eeprom_defaults_w:
 .endmacro
 .if USE_INT0 == 1
 .macro rcp_int_rising_edge
-		ldi	@0, (1<<ISC01) + (1<<ISC00) + SLEEP_FLAGS
-		out	MCUCR, @0	; set next int0 to rising edge
+		int0_set_rising_edge @0
 .endmacro
 .macro rcp_int_falling_edge
-		ldi	@0, (1<<ISC01) + SLEEP_FLAGS
-		out	MCUCR, @0	; set next int0 to falling edge
+		int0_set_falling_edge @0
 .endmacro
 .elif USE_INT0 == 2
 .macro rcp_int_rising_edge
-		ldi	@0, (1<<ISC01) + SLEEP_FLAGS
-		out	MCUCR, @0	; set next int0 to falling edge
+		int0_set_falling_edge @0
 .endmacro
 .macro rcp_int_falling_edge
-		ldi	@0, (1<<ISC01) + (1<<ISC00) + SLEEP_FLAGS
-		out	MCUCR, @0	; set next int0 to rising edge
+		int0_set_rising_edge @0
 .endmacro
 .endif
 .endif

--- a/tgy.asm
+++ b/tgy.asm
@@ -204,6 +204,10 @@
 .equ	DEBUG_ADC_DUMP	= 0	; Output an endless loop of all ADC values (no normal operation)
 .equ	MOTOR_DEBUG	= 0	; Output sync pulses on MOSI or SCK, debug flag on MISO
 
+.if !defined(USE_LED_PWM)
+.equ USE_LED_PWM	= 0	; set to 1/2/3 to set PWM fequency and brightness - 3 flashes already!
+.endif
+
 ; power saving when the motor is not running
 .if !defined(USE_SLEEP)
 .equ USE_SLEEP		= 0	; Sleep level to support (0 = none, 1 = idle, 2=adc)
@@ -3757,6 +3761,17 @@ set_brake_duty:	ldi2	temp1, temp2, MAX_POWER
 
 wait_for_power_on:
 		wdr
+	; GREEN-led PWM based on T1 overflow to save some power
+		.if USE_LED_PWM && defined(green_led)
+		lds	temp3, tcnt1x
+		andi	temp3, (1<<USE_LED_PWM)-1
+		brne	wait_for_power_blink_green_skip_on
+		GRN_on
+		rjmp	wait_for_power_blink_green_skip_off
+wait_for_power_blink_green_skip_on:
+		GRN_off
+wait_for_power_blink_green_skip_off:
+		.endif
 		.if USE_SLEEP
 		rcall	sleep_idle
 		.endif


### PR DESCRIPTION
Several patches that mean a big power reduction while the ESC is not running the motor:
* implement idle sleep
* implement adc-sleep (4096us timer is simulated via ADC interrupts)
* implement green-led PWM while not running
* implement an option to put FET into a low power configuration

Results:
* afro-nfet:
  * stock (1e4c017):
    * 45.2mA idle - no PWM
    * 53.5mA armed - with neutral PWM (difference to no-pwm is mostly green-LED)
    * 2094 Words
  * USE_SLEEP=2 and USE_LED_PWM=3:
    * 35.6mA idle - no PWM
    * 39.8mA armed - with neutral PWM (difference to no-pwm is mostly idle-sleep vs. adc-sleep)
    * 2177 Words
  * USE_FET_* = 1 + all sleep and led optimizations
    * 19.9mA idle - no PWM
    * 23.5mA armed - with neutral PWM (difference to no-pwm is mostly idle-sleep vs. adc-sleep)
    * 2198 Words
* tgy.inc:
  * stock (1e4c017):
    * 48.9mA idle - no PWM
    * 47.4mA armed - with neutral PWM (surprisingly this consumes less power)
    * 1773 Words
  * USE_SLEEP=2 and USE_LED_PWM=3:
    * 33.7mA idle - no PWM
    * 38.8mA armed - with neutral PWM (difference to no-pwm is mostly idle-sleep vs. adc-sleep)
    * 2177 Words
  * USE_FET_* = 1 + all sleep and led optimizations
    * not applicable, but there may be some low hanging fruit - see the stock reduction when armed!)

Note that the implementation is using adc, which can also get extended to allow for continuous ADC capturing while the motor is running and does not produce glitches at high RPM!

A patch that does averaging of 256 samples resulting in [0:65472] (2 bit decimated) is pending some final testing. Initial tests show that the time to capture is below 200ms per MUX channel @1MHz ADC clock.