### PR TITLE
Fix bootloader EEprom write bug

### DIFF
--- a/boot.inc
+++ b/boot.inc
@@ -537,6 +537,7 @@ scmd2:
 		cpi	r22, CMD_READ_EEPROM_ISP
 		breq	scmd_read_eeprom
 		adiw	YL, 7			; Skip useless write command bytes
+		clt
 		cpi	r22, CMD_PROGRAM_EEPROM_ISP
 		breq	scmd_program_eeprom
 		cpi	r22, CMD_PROGRAM_FLASH_ISP
@@ -697,7 +698,6 @@ boot_clear_fl1:	subi	ZL, low(2*PAGESIZE)	; Decrement by a page
 		ret
 
 ; Pad out the boot loader to work around avrdude verifying gaps
-		nop
 		nop
 
 		nop


### PR DESCRIPTION
Write to EEprom fails after jump to bootloader from within main
firmware.
Reason: T-Flag is used in main firmware and bootloader as well and needs
to be cleared.
clt inserted before CMD_PROGRAM_EEPROM_ISP to fix.
