### PR TITLE
Add support for NCP5106B based HK Blue Series 40A

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL = /bin/bash
 
 .SUFFIXES: .inc .hex
 
-ALL_TARGETS = afro.hex afro2.hex afro_hv.hex afro_nfet.hex arctictiger.hex birdie70a.hex bs_nfet.hex bs.hex bs40a.hex dlu40a.hex dlux.hex dys_nfet.hex hk200a.hex hm135a.hex hxt200a.hex kda.hex kda_8khz.hex kda_nfet.hex kda_nfet_ni.hex mkblctrl1.hex rb50a.hex rb70a.hex rb70a2.hex rct50a.hex tbs.hex tbs_hv.hex tp.hex tp_8khz.hex tp_i2c.hex tp_nfet.hex tp70a.hex tgy6a.hex tgy_8mhz.hex tgy.hex
+ALL_TARGETS = afro.hex afro2.hex afro_hv.hex afro_nfet.hex arctictiger.hex birdie70a.hex bs_nfet.hex bs.hex bs40a.hex bs40a_5106b.hex dlu40a.hex dlux.hex dys_nfet.hex hk200a.hex hm135a.hex hxt200a.hex kda.hex kda_8khz.hex kda_nfet.hex kda_nfet_ni.hex mkblctrl1.hex rb50a.hex rb70a.hex rb70a2.hex rct50a.hex tbs.hex tbs_hv.hex tp.hex tp_8khz.hex tp_i2c.hex tp_nfet.hex tp70a.hex tgy6a.hex tgy_8mhz.hex tgy.hex
 AUX_TARGETS = afro_pr0.hex afro_pr1.hex diy0.hex
 
 all: $(ALL_TARGETS)

--- a/bs40a_5106b.inc
+++ b/bs40a_5106b.inc
@@ -1,0 +1,56 @@
+;***************************************************************
+;* For HK Blue Series 40A (2016) -- same as "bs" but with      *
+;* different FET pins (NCP5106B drivers).                      *
+;* Fuses should be set to -U lfuse:w:0x2e:m -U hfuse:w:0xcf:m  *
+;* https://github.com/sim-/tgy                                 *
+;***************************************************************
+
+.equ	F_CPU		= 16000000
+.equ	USE_INT0	= 1
+.equ	USE_I2C		= 0	; We could, but FETs are on the I2C ports
+.equ	USE_UART	= 0
+.equ	USE_ICP		= 0
+
+;*********************
+; PORT D definitions *
+;*********************
+.equ	AnFET		= 5
+.equ	ApFET		= 4
+.equ	rcp_in		= 2
+
+.equ	INIT_PD		= 0
+.equ	DIR_PD		= (1<<AnFET)+(1<<ApFET)
+
+.equ	AnFET_port	= PORTD
+.equ	ApFET_port	= PORTD
+
+;*********************
+; PORT C definitions *
+;*********************
+.equ	mux_b		= 7	; ADC7
+.equ	mux_a		= 6	; ADC6
+.equ	BpFET		= 5
+.equ	BnFET		= 4
+.equ	CpFET		= 3
+.equ	mux_voltage	= 2	; ADC2 voltage input (220k from Vbat, 51k to gnd, 10.10V -> 1.900V at ADC2)
+.equ	mux_c		= 0	; ADC0
+
+.equ	O_POWER		= 220
+.equ	O_GROUND	= 51
+
+.equ	INIT_PC		= 0
+.equ	DIR_PC		= (1<<BpFET)+(1<<BnFET)+(1<<CpFET)
+
+.equ	BpFET_port	= PORTC
+.equ	BnFET_port	= PORTC
+.equ	CpFET_port	= PORTC
+
+;*********************
+; PORT B definitions *
+;*********************
+.equ	CnFET		= 0
+
+.equ	INIT_PB		= 0
+.equ	DIR_PB		= (1<<CnFET)
+
+.equ	CnFET_port	= PORTB

--- a/tgy.asm
+++ b/tgy.asm
@@ -104,6 +104,8 @@
 #include "bs_nfet.inc"		; HobbyKing BlueSeries / Mystery with all nFETs (INT0 PWM)
 #elif defined(bs40a_esc)
 #include "bs40a.inc"		; HobbyKing BlueSeries / Mystery 40A (INT0 PWM)
+#elif defined(bs40a_5106b_esc)
+#include "bs40a_5106b.inc"	; HobbyKing BlueSeries 40A with NCP5106B FET driver (INT0 PWM)
 #elif defined(dlu40a_esc)
 #include "dlu40a.inc"		; Pulso Advance Plus 40A DLU40A inverted-PWM-opto (INT0 PWM)
 #elif defined(dlux_esc)


### PR DESCRIPTION
The latest version of Hobbyking Blue Series 40A ESC uses the following pins to drive the FETs:

- An PD5
- Ap PD4
- Bn PC4
- Bp PC5
- Cn PB0
- Cp PC3

which is different from both `bs40a` and `bs_nfet`.

![hobbyking-blue-series-40a-ncp5106b](https://cloud.githubusercontent.com/assets/169055/24286985/51df2c38-1080-11e7-8744-738f675ddaa8.jpg)
